### PR TITLE
Tox domain change

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ See also [Static Site Generators](#static-site-generators) and  [Content Managem
   * [Rocket.Chat](http://rocket.chat/) – Teamchat solution similar to Gitter.im or Slack - `MIT`
   * [Synapse](https://matrix.org/blog/project/synapse/) - A server for [Matrix](https://matrix.org/), an open standard for decentralized persistent communication ([Source code](https://github.com/matrix-org/synapse)) `Apache` `Python`
     * [Matrix Console Web](https://matrix.org/blog/project/matrix-console-web/) - A web client meant to be a showcase of Matrix capabilities, and reference implementation of the Matrix standard ([Source code](https://github.com/matrix-org/matrix-angular-sdk)) `Apache` `Javascript`
-  * [Tox](https://tox.im/) -  A distributed, secure messenger with audio and video chat capabilities. `GPLv3` `C`
+  * [Tox](https://tox.chat/) -  A distributed, secure messenger with audio and video chat capabilities. `GPLv3` `C`
 
 ### Social Networks and Forums
 


### PR DESCRIPTION
The Tox primary domain has changed to [https://tox.chat](https://tox.chat), more details on [this blog post](https://blog.tox.chat/2015/07/current-situation-3/)