### PR TITLE
Add Factor.io to the Continuous Integration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,7 @@ See **[Ticketing](#ticketing)**
 
 ### Continuous Integration
 
+  * [Factor.io](https://factor.io/) - It's like IFTTT (if-this-then-that) for Dev and DevOps ([Source code](https://github.com/factor-io/factors)) `MIT` `Ruby`
   * [Jenkins](https://jenkins-ci.org/) - Continuous Integration Server ([Source Code](https://github.com/jenkinsci/jenkins/)) `MIT` `Java`
   * [PHPCI](https://www.phptesting.org/) - Free and open source continuous integration specifically designed for PHP ([Source Code](https://github.com/block8/phpci)) `BSD` `PHP`
 


### PR DESCRIPTION
From the homepage:

>  "It's like IFTTT (if-this-then-that) for Dev and DevOps"
> Factor.io is a simple way to automate developer workflows by defining them programmatically using the Factor.io syntax and running them using the Factor.io Server.

Still not sure about the license. Moreover I cannot find the source code anywhere other than Ruby Gem repository. 