### PR TITLE
Add MyBB forum software to Social Networks/Forums section

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ _[Extensible Messaging and Presence Protocol](https://en.wikipedia.org/wiki/XMPP
   * [Isso](http://posativ.org/isso/) - a lightweight commenting server written in Python and JavaScript. It aims to be a drop-in replacement for Disqus ([Source code](https://github.com/posativ/isso)) `MIT` `Python`
   * [Jappix](https://jappix.com/) - Jappix is an open social platform, that let's you easily get or keep in touch with everyone.
   * [Movim](https://movim.eu/) - A brand new social network, full of awesome features in a modern and smart interface
+  * [MyBB](http://mybb.com) - Free, extensible forum software package. ([Source Code](https://github.com/mybb/mybb)) `LGPLv3` `PHP` 
   * [Newebe](http://newebe.org/) - a Distributed Social Network ([Source code](https://github.com/gelnior/newebe)) `AGPLv3` `Python`
   * [NodeBB](https://nodebb.org/) - Node.js based forum software built for the modern web ([Source code](https://github.com/NodeBB/NodeBB)) `GPLv3` `Node.js`
   * [Oxwall](http://www.oxwall.org/) Oxwall is used for a wide range of projects starting from family sites and custom social networks to collaboration tools and enterprise community solutions. ([Source code](https://bitbucket.org/oxwall/public) `CPALv1` `PHP`


### PR DESCRIPTION
Seeing as other forum software packages are in the Social Networks and Forums section, I request to add the MyBB forum software to the selection.

To demonstrate activity/presence:

Main site: http://mybb.com
Community Forum (our pseudo-demo): http://community.mybb.com
Development Blog: http://blog.mybb.com
Twitter account: https://twitter.com/mybb
GitHub Organization: https://github.com/mybb
MyBB 1.x (current) repo: https://github.com/mybb/mybb

Disclaimer: I am a Community Liaison for the MyBB Group (developers of the software). I have described the software in what I believe to be a terse, unbiased way.

Thank you,
Josh Harmon