### PR TITLE
Add TournamentMango

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ Some [Groupware](#groupware) solutions also feature file sharing and synchroniza
   * [20euros](https://github.com/jatekos101/20euros) - Clone of 2048 game with euros. - Unlicensed
   * [Agar.IO Clone](https://github.com/huytd/agar.io-clone) - Agar.io clone written with Socket.IO and HTML5 canvas - `MIT`
   * [Cubiks-2048](https://github.com/Kshitij-Banerjee/Cubiks-2048) - Clone of 2048 game in 3D. - `CCANC 4.0`
+  * [TournamentMango](http://tournamentmango.com/) - TournamentMango is an open source tournament bracket and user management system. You can build an archive of players and keep track of all their scores over time as well as their regular characters, games, and aliases. ([Source code](https://github.com/seiyria/tournamentmango)) `MIT` `Javascript`
 
 
 ## Gateways


### PR DESCRIPTION
TournamentMango is a games tournament organisation system. Currently it is in the games section, however we could look at creating an entirely new section or sub-section for this project.

What do you think @nodiscc?