### PR TITLE
Changed the pydio adress from pyd.io to pydio.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ Some [Groupware](#groupware) solutions also feature file sharing and synchroniza
   * [Syncthing](https://syncthing.net/) - Syncthing is an open source peer-to-peer file synchronisation tool. ([Source Code](https://github.com/syncthing/syncthing)) `MPLv2` `Go`
   * [Z-Push](https://z-push.org/) - An implementation of Microsoft’s [ActiveSync](https://en.wikipedia.org/wiki/ActiveSync) protocol
   * [ownCloud](https://owncloud.org/) - All-in-one solution for saving, synchronizing, viewing, editing and sharing files, calendars, address books and more - `AGPLv3` `PHP`
-  * [Pydio](https://pyd.io/) - Turn any web server into a powerful file management system and an alternative to mainstream cloud storage providers.
+  * [Pydio](https://pydio.com/) - Turn any web server into a powerful file management system and an alternative to mainstream cloud storage providers.
 
 
 #### Peer-to-peer filesharing


### PR DESCRIPTION
Pydio moved from pyd.io to pydio.com and tries to redirect everyone who visits pyd.io. I updated the address because of that.