### PR TITLE
Fix Kanboard license

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,7 +850,7 @@ See https://staticsitegenerators.net and https://www.staticgen.com
 
   * [bulldog](https://github.com/infews/bulldog) - HTML5 task manager, built on todo.txt. `MIT` `HTML5`
   * [Crepido](https://github.com/arshad/crepido) - Create (kanban) boards to track users and projects from flat markdown files. `MIT` `Javascript/Others`
-  * [Kanboard](http://kanboard.net/) - A simple and open source visual task board. `AGPLv3`
+  * [Kanboard](http://kanboard.net/) - A simple and open source visual task board. `MIT`
   * [myTinyTodo](http://www.mytinytodo.net/) - Simple way to manage your todo list in AJAX style. Uses PHP, jQuery, SQLite/MySQL. GTD compliant. `GPL`
   * [omgnata](https://github.com/chr15m/omgnata) - Mobile friendly zero-feature TODO list web app. Unix philosophy. ([Demo](https://chr15m.github.io/omgnata/)) `GPLv3` `ClojureScript`
   * [Restyaboard](http://restya.com/board/) - Open source Trello-like kanban board. ([Demo](http://restya.com/board/demo.html), [Source Code](https://github.com/RestyaPlatform/board)) `OSL v3.0` `PHP`


### PR DESCRIPTION
Kanboard is MIT-licensed, not AGPL3. Ref: https://github.com/kanboard/kanboard/blob/master/LICENSE