### PR TITLE
updated & corrected OpenEats

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ CMS are a practical way to setup a website with many features. CMS often come wi
 
 _Recipe management_
 
-  * [OpenEats](http://www.openeats.org/) - A recipe management site that allows users to create, store, share and rate recipes, create grocery lists, and more. ([Source Code](https://github.com/RyanNoelk/OpenEats)) `BSD` `Python`
+  * [OpenEats](https://github.com/RyanNoelk/OpenEats) - A recipe management site that allows users to create, store, share and rate recipes, create grocery lists, and more. ([Demo](https://food.ryannoelk.com/)) `MIT` `Python`
 
 ### E-commerce
 


### PR DESCRIPTION
- the real homepage (the demo-site was linked instead) of the stalled project would have been http://dev.openeats.org/
--> i linked - like usual, when there's no homepage - the github-site from the active project instead, because it went through huge evolution (see demo).
- added the demo of the active project: https://food.ryannoelk.com/
- removed sourcecode-link, since is identical to the homepage-link
- the license was completely false: the original project was under GPLv2 and the fork is under MIT