### PR TITLE
Ambiguos indent removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1098,7 +1098,7 @@ See https://staticsitegenerators.net and https://www.staticgen.com
 
   * [Crepido](https://github.com/arshad/crepido) - Create (kanban) boards to track users and projects from flat markdown files. `MIT` `Nodejs`
   * [Kanboard](http://kanboard.net/) - A simple and open source visual task board. ([Source Code](https://github.com/kanboard/kanboard)) `MIT` `PHP`
-    * [Wheatbin](http://wheatbin.com/) - A project management software that combines Kanban methodology with the Law of the Harvest. ([Source Code](https://github.com/wheatbin/wheatbin)) `MIT` `PHP`
+  * [Wheatbin](http://wheatbin.com/) - A project management software that combines Kanban methodology with the Law of the Harvest. ([Source Code](https://github.com/wheatbin/wheatbin)) `MIT` `PHP`
   * [myTinyTodo](http://www.mytinytodo.net/) - Simple way to manage your todo list in AJAX style. Uses PHP, jQuery, SQLite/MySQL. GTD compliant. `GPLv2` `PHP`
   * [omgnata](https://github.com/chr15m/omgnata) - Mobile friendly zero-feature TODO list web app. Unix philosophy. ([Demo](https://chr15m.github.io/omgnata/)) `GPLv3` `ClojureScript`
   * [PHP Task/Todo list](https://github.com/lgg/tasks.php) - A simple task/todo list that uses a JSON text file for the tasks. `MIT` `PHP`


### PR DESCRIPTION
Wheatbin was indented one level too much and looked like a part of Kanboard, which it is not.

Thank you for taking the time to work on a PR for Awesome-Selfhosted!

To ensure your PR is dealt with swiftly please check the following:

- [x] Your submissions are formatted according to the guidelines. 
        
    ``[Name](http://homepage/) - Short description. ([Demo](http://url.to/demo), [Source Code](http://url.of/source/code)) `License` `Language` ``

- [x] Your additions are ordered alphabetically.
- [x] Your additions are [Free software](https://en.wikipedia.org/wiki/Free_software), or if not they have been added to [non-free](non-free.md).
- [x] Your additions are not already listed at [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin) (IT infrastructure management), [staticgen.com](https://www.staticgen.com/) or [staticsitegenerators.net](https://staticsitegenerators.net/) (static site generators).
- [x] Any licenses you have added are in our [list of licenses](https://github.com/Kickball/awesome-selfhosted/blob/master/README.md#list-of-licenses).
- [x] You have searched the repository for any relevant issues or PRs.
- [x] Any category you are creating has the minimum requirement of 3 items.
