### PR TITLE
added link to the nextcloud app-store

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ See https://github.com/n1trux/awesome-sysadmin#distributed-filesystems
 
   * [Git Annex](http://git-annex.branchable.com) - File synchronization between computers, servers, external drives. ([Source Code](https://github.com/joeyh/git-annex)) `GPLv3` `Haskell`
   * [Kinto](https://kinto.readthedocs.org) - Kinto is a minimalist JSON storage service with synchronisation and sharing abilities. ([Source Code](https://github.com/Kinto)) `Apache` `Python`
-  * [Nextcloud](https://nextcloud.com/) - Access & share your files, calendars, contacts, mail & more from any device, on your terms. ([Demo](https://demo.nextcloud.com/), [Source Code](https://github.com/nextcloud/server)) `AGPLv3` `PHP`
+  * [Nextcloud](https://nextcloud.com/) - Access & share your files, calendars, contacts, mail & [more](https://apps.nextcloud.com/) from any device, on your terms. ([Demo](https://demo.nextcloud.com/), [Source Code](https://github.com/nextcloud/server)) `AGPLv3` `PHP`
   * [OpenSSH/SFTP](http://www.openssh.com/) - Secure File Transfer Program. ([Source Code](http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh)) `BSD` `C`
   * [ownCloud](https://owncloud.org/) - All-in-one solution for saving, synchronizing, viewing, editing and sharing files, calendars, address books and more. ([Source Code](https://github.com/owncloud/core)) `AGPLv3` `PHP`
   * [Pydio](https://pydio.com/) - Turn any web server into a powerful file management system and an alternative to mainstream cloud storage providers. ([Source Code](https://github.com/pydio/pydio-core)) `AGPLv3` `PHP`


### PR DESCRIPTION
regarding #1095 i added just a link to the nextcloud app-store, since i also see usual links at other entries and it only lists [Free software](https://en.wikipedia.org/wiki/Free_software) with licenses that are in our [list of licenses](https://github.com/Kickball/awesome-selfhosted/blob/master/README.md#list-of-licenses). - like [already mentioned](https://github.com/Kickball/awesome-selfhosted/issues/1095#issuecomment-313120321) only AGPLv3, MPL 2.0 or Apache License 2.0 are allowed.
i hope this is ok?