### PR TITLE
Remove Fever From Proprietary List

### DIFF
--- a/non-free.md
+++ b/non-free.md
@@ -31,11 +31,6 @@
 
   * [Auth0](https://auth0.com/docs/appliance): `⊘ Proprietary`. Identity made simple for developers. `NodeJS`
 
-  
-## Feed Readers
-
-  * [Fever](http://feedafever.com/) `⊘ Proprietary` - Self-hosted feed aggregator that can sort items by popularity `PHP`
-
 
 ## File Sharing and Synchronization
 


### PR DESCRIPTION
Removed Fever from non-free.md proprietary list. Developer has discontinued sales and support, per website at feedafever.com.

Thank you for taking the time to work on a PR for Awesome-Selfhosted!

To ensure your PR is dealt with swiftly please check the following:

- [x] Your submissions are formatted according to the guidelines. 