### PR TITLE
add IndieWeb to communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1341,7 +1341,7 @@ See also [Documentation Generators](#documentation-generators), [Wikimatrix](htt
  * [Awesome Sysadmin](https://github.com/n1trux/awesome-sysadmin) - A curated list of amazingly awesome open source sysadmin resources.
  * [PRISM Break](https://prism-break.org/en/), [privacytools.io](https://www.privacytools.io/), [Alternative Internet](https://redecentralize.github.io/alternative-internet/), [Libre Projects](http://libreprojects.net/) - Lists of software aimed at privacy and decentralization (in some form).
  * Dynamic Domain Name services: [Afraid.org](https://freedns.afraid.org/domain/registry/), [Pagekite](https://pagekite.net/)
- * Communities/forums: [/r/selfhosted](https://www.reddit.com/r/selfhosted), [Auto-Hébergement (FR)](http://www.auto-hebergement.fr/)
+ * Communities/forums: [/r/selfhosted](https://www.reddit.com/r/selfhosted), [IndieWeb](https://indieweb.org/), [Auto-Hébergement (FR)](http://www.auto-hebergement.fr/)
 
 -------------------------------------------------------
 


### PR DESCRIPTION
- [x] Your submissions are formatted according to the guidelines. 
        
> https://indieweb.org/
> The IndieWeb is a people-focused alternative to the "corporate web". 