### PR TITLE
Remove my name + email address from AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -37,8 +37,6 @@ Commits | Author
      4 | Alexandr Emelin <frvzmb@gmail.com>
      4 | AndrewCz <smacz42@users.noreply.github.com>
      4 | Chris McCormick <chris@mccormick.cx>
-     4 | Colin Pokowitz <colin@cpdev.me>
-     4 | Colin Pokowitz <colinpokowitz03@gmail.com>
      4 | Cory Gibbons <hello@corygibbons.com>
      4 | D <DL88250@gmail.com>
      4 | Dominik Pfaffenbauer <dominik@lineofcode.at>


### PR DESCRIPTION
Hello there. A while ago, I contributed some formatting changes, additions, and other issues to this project. Those commits added my name and multiple email addresses to the AUTHORS.md file. I would like those removed as I am now getting various spam emails because of it. As well as other people from Github, probably people on this list (see screenshot) If this commit could be merged that would be great.

This is the seventh spam email I have gotten in the past 5 days, and this is the only place my name is on the internet and as you can see there are other Github email addresses sent this calendar inv.
![image](https://user-images.githubusercontent.com/16247799/35696895-5131b178-074e-11e8-9772-2d7335ba9d04.png)

