### PR TITLE
Rename Stash to BitBucket Server

### DIFF
--- a/non-free.md
+++ b/non-free.md
@@ -103,7 +103,7 @@
   * [Documize](https://documize.com) `⊘ Proprietary` - Modern docs & wiki software built for software team collaboration. `Go`
   * [JIRA](https://www.atlassian.com/software/jira) `⊘ Proprietary` - A professional and extensible issue tracker `Java`
   * [RhodeCode](https://rhodecode.com) `⊘ Proprietary` - On-premise Source Code Management for Mercurial, Git & Subversion. `Python`
-  * [Stash](https://www.atlassian.com/software/stash) `⊘ Proprietary` - An enterprise-level Git solution similar to GitLab `Java`
+  * [BitBucket Server](https://www.atlassian.com/software/bitbucket/server) `⊘ Proprietary` - An enterprise-level Git solution similar to GitLab `Java`
 
   
 ## Ticketing


### PR DESCRIPTION
Atlassian renamed Stash to BitBucket server back in 2015, and it looks like `non-free.md` never got updated. See https://confluence.atlassian.com/bitbucketserver/bitbucket-rebrand-faq-779298912.html

---

Thank you for taking the time to work on a PR for Awesome-Selfhosted!

To ensure your PR is dealt with swiftly please check the following:

- [x] Your submissions are formatted according to the guidelines. 
        
    ``- [Name](http://homepage/) - Short description, less than 250 characters. ([Demo](http://url.to/demo), [Source Code](http://url.of/source/code)) `License` `Language` ``

- [x] Your additions are ordered alphabetically.
- [x] Your additions are [Free software](https://en.wikipedia.org/wiki/Free_software), or if not they have been added to [non-free](non-free.md).
- [x] Your additions are not already listed at [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin) (IT infrastructure management), [staticgen.com](https://www.staticgen.com/) or [staticsitegenerators.net](https://staticsitegenerators.net/) (static site generators).
- [x] Any licenses you have added are in our [list of licenses](https://github.com/Kickball/awesome-selfhosted/blob/master/README.md#list-of-licenses).
- [x] You have searched the repository for any relevant [issues](https://github.com/Kickball/awesome-selfhosted/issues) or [PRs](https://github.com/Kickball/awesome-selfhosted/pulls).
- [x] Any category you are creating has the minimum requirement of 3 items.
- [x] Any software project you are adding to the list is actively maintained.