### PR TITLE
Fair Source License is not a FLOSS license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1324,7 +1324,6 @@ See also [Documentation Generators](#documentation-generators), [Wikimatrix](htt
 - `DPL` - [Devblocks Public License 1.0](https://cerb.ai/license/)
 - `ECL-2.0` - [Educational Community License, Version 2.0 ](http://opensource.org/licenses/ECL-2.0)
 - `EPL-1.0` - [Eclipse Public License, Version 1.0](https://www.eclipse.org/legal/epl-v10.html)
-- `Fair` - [Fair License](https://fair.io/)
 - `GPL-1.0` - [GNU General Public License](https://www.gnu.org/licenses/gpl-1.0)
 - `GPL-2.0` - [GNU General Public License 2.0](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 - `GPL-3.0` - [GNU General Public License 3.0](http://www.gnu.org/licenses/gpl-3.0.en.html)


### PR DESCRIPTION
according to .github/CONTRIBUTING.md, the main list must only contain Free Software.
Fair Source License does not meet any authoritative definition of FLOSS (FSF, Debian, OSI)
In their words: "The Fair Source License is not an open-source license and doesn’t intend to be an open-source license."
