### PR TITLE
Remove Emby from FOSS listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,7 +862,6 @@ See also <https://en.wikipedia.org/wiki/List_of_streaming_media_systems>, <https
 
 - [crtmpserver](https://packages.debian.org/stable/crtmpserver) - High performance RTMP/RTSP streaming server. `GPL-3.0` `C++`
 - [CyTube](https://github.com/calzoneman/sync) - CyTube is a web application providing media synchronization, chat, and more for an arbitrary number of channels. ([Demo](http://cytu.be)) `MIT` `Nodejs`
-- [Emby](https://emby.media/) - Home media server supporting both DLNA and DIAL (Chromecast) devices out-of-the-box. ([Source Code](https://github.com/MediaBrowser/Emby)) `GPL-2.0` `C#`
 - [Hellowlol HTPC Manager fork](https://github.com/Hellowlol/HTPC-Manager) - Fully responsive interface to manage all your favorite media on your HTPC. ([Source Code](https://github.com/styxit/HTPC-Manager)) `MIT` `Python`
 - [Icecast 2](http://www.icecast.org/) - streaming audio/video server which can be used to create an Internet radio station or a privately running jukebox and many things in between. ([Source Code](https://git.xiph.org/?p=icecast-server.git;a=summary), [Clients](https://www.icecast.org/apps/)) `GPL-2.0` `C`
 - [MistServer](http://mistserver.org/) - Streaming media server that works well in any streaming environment. ([Source Code](https://github.com/DDVTECH/mistserver)) `AGPL-3.0` `C++`

--- a/non-free.md
+++ b/non-free.md
@@ -53,6 +53,7 @@
 
 ## Media Streaming
 
+  * [Emby](https://emby.media/) `⊘ Proprietary` - Home media server supporting both DLNA and DIAL (Chromecast) devices out-of-the-box. ([Partial source Code](https://github.com/MediaBrowser/Emby)) `Proprietary with some GPL-2.0` `C#`
   * [Plex](https://plex.tv/) `⊘ Proprietary` - Plex is a centralized home media playback system with a powerful central server.
   * [Subsonic](http://subsonic.org/) - Web-based media streamer and jukebox. ([Demo](http://demo.subsonic.org/login.view?user=guest4&password=guest))
 


### PR DESCRIPTION
While a portion of Emby's code is licensed under the GPL-2, it cannot run without using proprietary blobs. See https://github.com/MediaBrowser/Emby/issues/3195

As of the latestest release 3.5.0.0, additional core code has been transitioned to sourceless blobs.
https://github.com/MediaBrowser/Emby/issues/3376

**-------**



Thank you for taking the time to work on a PR for Awesome-Selfhosted!



To ensure your PR is dealt with swiftly please check the following:

- [X] Your submissions are formatted according to the guidelines. 
        
    ``- [Name](http://homepage/) - Short description, less than 250 characters. ([Demo](http://url.to/demo), [Source Code](http://url.of/source/code), [Clients](https://url.to/list/of/related/clients-or-apps)) `License` `Language` ``

- [X] Your additions are ordered alphabetically.
- [X] Your additions are [Free software](https://en.wikipedia.org/wiki/Free_software), or if not they have been added to [non-free](non-free.md) and marked `⊘ Proprietary`.
- [X] Your additions are not already listed at [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin) (IT infrastructure management), [staticgen.com](https://www.staticgen.com/) or [staticsitegenerators.net](https://staticsitegenerators.net/) (static site generators).
- [X] Your additions have their `License` main server-side `Language`/platform/requirement listed.
- [X] Any licenses you have added are in our [list of licenses](https://github.com/Kickball/awesome-selfhosted/blob/master/README.md#list-of-licenses).
- [X] You have searched the repository for any relevant [issues](https://github.com/Kickball/awesome-selfhosted/issues) or [PRs](https://github.com/Kickball/awesome-selfhosted/pulls), incluing closed ones.
- [X] If the main link of your addition points to the program's source code, there is no need to add a duplicate _Source Code_ link. The _Demo_ and _Clients_ links are not mandatory.
- [X] Any category you are creating has the minimum requirement of 3 items. If not, your addition may be inserted into `Misc/Other`.
- [X] Any software project you are adding to the list is actively maintained.