### PR TITLE
Add MailCare to Webmail clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ _Mailing lists servers and mass mailing software - one message to many recipient
 - [Cypht](http://cypht.org/index.html) - Feed reader for your email accounts. ([Source Code](https://github.com/jasonmunro/hm3)) `GPL-2.0` `PHP`
 - [Disposable Mailbox](https://github.com/synox/disposable-mailbox) - Simple disposable mailbox web-app based on a catch-all IMAP mailbox. ([Demo](https://bhadoomail.com/)) `GPL-3.0` `PHP`
 - [IMP](https://www.horde.org/apps/imp/) - HORDE application that provides webmail access to IMAP and POP3 accounts. ([Demo](http://demo.horde.org/), [Source Code](https://www.horde.org/download/imp)) `GPL-2.0` `PHP`
+- [MailCare](https://mailcare.io) - Open source disposable email address service. ([Source Code](https://github.com/mailcare/mailcare)) `MIT` `PHP`
 - [Mailpile](https://www.mailpile.is/) - Webmail client with search, filtering, encryption features and more. ([Source Code](https://github.com/mailpile/Mailpile)) `AGPL-3.0` `Python`
 - [RainLoop](http://www.rainloop.net/) - Simple, modern and fast webmail with IMAP/SMTP Support and multi accounting. ([Demo](http://demo.rainloop.net/), [Source Code](https://github.com/RainLoop/rainloop-webmail)). `AGPL-3.0` `PHP`
 - [Roundcube](https://roundcube.net) - Browser-based IMAP client with an application-like user interface. ([Source Code](https://github.com/roundcube/roundcubemail/)) `GPL-3.0` `PHP`


### PR DESCRIPTION
MailCare is a open source disposable email address service built on top of Laravel (PHP) and VueJS.

We should have a mail server like postfix to add a catch-all, and MailCare will be able to parse the incoming email (with the lib php-mime-mail-parser) and show/search emails like any webmail.


- [X] Your submissions are formatted according to the following requirements:
        
``- [Name](http://homepage/) - Short description, less than 250 characters. ([Demo](http://url.to/demo), [Source Code](http://url.of/source/code), [Clients](https://url.to/list/of/related/clients-or-apps)) `License` `Language` ``

- [X] Your additions are ordered alphabetically.
- [X] Your additions are [Free software](https://en.wikipedia.org/wiki/Free_software), or if not they have been added to [non-free](non-free.md) and marked `⊘ Proprietary`.
- [X] Your additions are not already listed at [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin) (IT infrastructure management), [staticgen.com](https://www.staticgen.com/) or [staticsitegenerators.net](https://staticsitegenerators.net/) (static site generators).
- [X] Your additions have their `License` main server-side `Language`/platform/requirement listed.
- [X] You have searched the repository for any relevant [issues](https://github.com/Kickball/awesome-selfhosted/issues) or [PRs](https://github.com/Kickball/awesome-selfhosted/pulls), incluing closed ones.
- [X] If the main link of your addition points to the program's source code, there is no need to add a duplicate _Source Code_ link. The _Demo_ and _Clients_ links are not mandatory.
- [X] Any software project you are adding to the list is actively maintained.
