### PR TITLE
Add gitlab.com mirror to external links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1467,6 +1467,7 @@ See also [Documentation Generators](#documentation-generators), [Wikimatrix](htt
 - Lists of software aimed at privacy and decentralization in some form: [PRISM Break](https://prism-break.org/en/), [privacytools.io](https://www.privacytools.io/), [Alternative Internet](https://redecentralize.github.io/alternative-internet/), [Libre Projects](http://libreprojects.net/)
 - Dynamic Domain Name services: [Afraid.org](https://freedns.afraid.org/domain/registry/), [Pagekite](https://pagekite.net/)
 - Communities/forums: [/r/selfhosted](https://www.reddit.com/r/selfhosted), [IndieWeb](https://indieweb.org/)
+- Mirrors: [GitHub.com](https://github.com/Kickball/awesome-selfhosted), [Gitlab.com](https://github.com/nodiscc/awesome-selfhosted)
 
 --------------------
 


### PR DESCRIPTION
I have set up a mirror of the repository on gitlab.com
The git repository itself is mirrored/updated automatically
Issues are not updated automatically

Thank you for taking the time to work on a PR for Awesome-Selfhosted!

To ensure your PR is dealt with swiftly please check the following:

- [x] You have searched the repository for any relevant [issues](https://github.com/Kickball/awesome-selfhosted/issues) or [PRs](https://github.com/Kickball/awesome-selfhosted/pulls), incluing closed ones.
- [x] Any software project you are adding to the list is actively maintained.
