### PR TITLE
remove wheatbin (unmaintained, never was)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1290,7 +1290,6 @@ See https://staticsitegenerators.net and https://www.staticgen.com
 - [Tracks](http://www.getontracks.org/) - Web-based application to help you implement David Allen’s [Getting Things Done™](https://en.wikipedia.org/wiki/Getting_Things_Done) methodology. ([Source Code](https://github.com/TracksApp/tracks)) `GPL-2.0` `Ruby`
 - [Volition](https://www.usevolition.com) - Opinionated open-source task management. ([Demo](https://www.usevolition.com/today/new?guest=true), [Source Code](https://github.com/garrettqmartin8/volition)) `MIT` `Ruby`
 - [Wekan](https://wekan.github.io/) - Open-source Trello-like kanban. ([Demo](https://oasis.sandstorm.io/appdemo/m86q05rdvj14yvn78ghaxynqz7u2svw6rnttptxx49g1785cdv1h), [Source Code](https://github.com/wekan/wekan)) `MIT` `Nodejs`
-- [Wheatbin](http://wheatbin.com/) - Project management software that combines Kanban methodology with the Law of the Harvest. ([Source Code](https://github.com/wheatbin/wheatbin)) `MIT` `PHP`
 
 ## Ticketing
 


### PR DESCRIPTION
- Was Forked from Kanboard in 2015
- No actual work was done after the fork, only doc/branding updates
- See https://github.com/wheatbin/wheatbin/commits/master?before=779a14497464d39f11af88547cb89317901e427b+105
- Last issue report from 2017 https://github.com/wheatbin/wheatbin/issues
- Kanboard is is still active https://github.com/kanboard/kanboard and listed here

Thank you for taking the time to work on a PR for Awesome-Selfhosted!

To ensure your PR is dealt with swiftly please check the following:

- [x] Your submissions are formatted according to the following requirements:
- [x] Your additions are [Free software](https://en.wikipedia.org/wiki/Free_software), or if not they have been added to [non-free](non-free.md) and marked `⊘ Proprietary`.
- [x] Any software project you are adding to the list is actively maintained.

Ref. https://github.com/Kickball/awesome-selfhosted/issues/1013