### PR TITLE
"Add encrypted oauth key for travis."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: node_js
 
 node_js:
   - "node"
-
+  
+env:
+  global:
+    - secure: "PyOX7l+atMbQ5VoaPMM3VIdUfwioFnjZcwpBJOGPAOhpxwnRwVd/5mrPbnjC5F/GnSSEmZL2hFcxDBlVX4XTRMDXjrhkdiHHr8sXHVJ+JmTYCxHfr4HSICuLcqtopl0RtNRcbk6arIZqd0jij6pJQDgZ3Jt5er6GNZTBluUUEmdvtjoGtex3PJ1ZoE46bf7l+PhyUHT2yqUg8XrJbAr9DwerT4YMZzxjfFMlJV/A5RbtpXGty5s1RmD+xhEaj8kqVu+ln5t7A8anHaw/BX+Txm/1B2EEgWx2IiZ2JcZsM1jM5irrsQH/gX/x133mx5ta1P/06d5iD9GD/vJTrPZz+d0UGUlxNadXtaPHWUUvxKtaTLB6vHk8Kzs1Be/e0DL7KbO5pjw4KOWgnUPntLYM+btk3Q5IHC0G8z5H/W0PW2SoqpL99PNbSqcLUkK6kcJBrnCZKfoQHwgB5Oe9X0go/L3RD0Qu7w4jPBJFZI7139wvhs4jz5Vh7Au61fHNMOvNstZsyDvE5hraz2bbzIJqyVV8EJqFe6G5kSOiMbm6gtq/emtBVY+De68w2PUNyMBXJ0LpBunyi8NmLy8UzaXIAzk6Ko/mldVx4qkspP++cmIh79hitETEwG9mwqcK27hst/BfQ64jHPCyLZTA6Zm1l60/jDTbb+NEoKY9sLeJ7M0="
 before_install:
   - rvm install 2.6.2
   - gem install awesome_bot


### PR DESCRIPTION
Adds encrypted oauth token to travis config https://docs.travis-ci.com/user/environment-variables#defining-encrypted-variables-in-travisyml

This may not work.  Danger.systems recommends the current config https://danger.systems/guides/getting_started.html with outh token in the open.  It does currently only have public repo access, and key is currently revoked.